### PR TITLE
chore: release v0.1.0

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -3,12 +3,12 @@ name: Release-plz
 on:
   push:
     branches:
-      - 
+      - main
 
 jobs:
   release-plz-release:
     name: Release-plz release
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     if: ${{ github.repository_owner == 'davehorner' }}
     permissions:
       contents: write
@@ -19,7 +19,10 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_PLZ_TOKEN }}
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: x86_64-pc-windows-msvc
       - name: Run release-plz
         uses: release-plz/action@v0.5
         with:
@@ -30,7 +33,7 @@ jobs:
 
   release-plz-pr:
     name: Release-plz PR
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     if: ${{ github.repository_owner == 'davehorner' }}
     permissions:
       pull-requests: write
@@ -45,7 +48,10 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_PLZ_TOKEN }}
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: x86_64-pc-windows-msvc
       - name: Run release-plz
         uses: release-plz/action@v0.5
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/davehorner/startt/releases/tag/v0.1.0) - 2025-05-08
+
+### Other
+
+- `startt` solves a long-standing Windows poor design/quirk: when you do

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,7 +141,6 @@ dependencies = [
  "clap",
  "widestring",
  "winapi",
- "windows",
 ]
 
 [[package]]
@@ -200,107 +199,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows"
-version = "0.61.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5ee8f3d025738cb02bad7868bbb5f8a6327501e870bf51f1b455b0a2454a419"
-dependencies = [
- "windows-collections",
- "windows-core",
- "windows-future",
- "windows-link",
- "windows-numerics",
-]
-
-[[package]]
-name = "windows-collections"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
-dependencies = [
- "windows-core",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.61.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
-]
-
-[[package]]
-name = "windows-future"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a1d6bbefcb7b60acd19828e1bc965da6fcf18a7e39490c5f8be71e54a19ba32"
-dependencies = [
- "windows-core",
- "windows-link",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.60.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.59.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-link"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
-
-[[package]]
-name = "windows-numerics"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
-dependencies = [
- "windows-core",
- "windows-link",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
-dependencies = [
- "windows-link",
-]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,11 +9,11 @@ repository  = "https://github.com/davehorner/startt"
 homepage    = "https://github.com/davehorner/startt"
 documentation = "https://docs.rs/startt"
 readme      = "README.md"
-keywords    = ["windows", "cli", "automation", "hwnd", "shell", "shellexecute"]
+keywords    = ["windows", "cli", "hwnd", "shell", "shellexecute"]
 categories  = ["command-line-utilities", "windows"] 
 
 [dependencies]
 clap = { version = "4.5.37", features = ["derive"] }
 widestring = "1.2.0"
-winapi = { version = "0.3.9", features = ["handleapi", "libloaderapi", "psapi", "shellapi", "tlhelp32", "winbase", "winuser"] }
-windows = { version = "0.61.1", features = ["Win32_Foundation", "Win32_UI_Shell", "Win32_System_Threading","Win32_UI_WindowsAndMessaging","Win32_System_Registry"] }
+winapi = { version = "0.3.9", features = ["handleapi", "libloaderapi", "psapi", "shellapi", "tlhelp32", "winbase", "winuser","minwindef","windef","winnt","processthreadsapi"] }
+# windows = { version = "0.61.1", features = ["Win32_Foundation", "Win32_UI_Shell", "Win32_System_Threading","Win32_UI_WindowsAndMessaging","Win32_System_Registry"] }


### PR DESCRIPTION



## 🤖 New release

* `startt`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.0](https://github.com/davehorner/startt/releases/tag/v0.1.0) - 2025-05-08

### Other

- `startt` solves a long-standing Windows poor design/quirk: when you do
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).